### PR TITLE
Removed assnat api project from the project list

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -24,40 +24,6 @@ Contributing to this project is within almost everybody's reach. Here's the skil
 * Basic understanding of how Gradle projects work
 * Access to Omnivox
 
-## AssNat API
-
-This a REST API for the National Assembly of Quebec (*Assemblée Nationale du Québec* in its original French, often shortened as *AssNat*), which is the legislative body of Quebec, Canada. That's where the MPs vote laws and do a bunch of other things. The API aims to help developers and non-developers to better get information about the Assembly.
-
-The API was developped 9 years ago by GitHub user [mna](https://github.com/mna), who did not update it since. It is now archived, meaning that the original repo is in read-only mode. That is why I [forked](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the repository under [mehdiben7/assnatapi](https://github.com/mehdiben7/assnatapi). It is quite important to note that since the original author of the code distributed the project under the open-source [MIT License](https://github.com/mna/assnatapi/blob/master/LICENSE), contributors need to keep the same license and copyright notice.
-
-#### The project state
-
-This API needs a lot of love. The API is not hosted in the cloud anymore and probably does not work at the moment, since the AssNat website changed a lot in the past years. The version of the technologies used in this project are also out of date. But I think this project is very interesting so I intend on making it rise from its ashes.
-
-#### Contributing
-
-This is a cool project that needs support to make it up to date.
-If any other Vanier FLOSS member want to contribute to the project, we can talk about it on the Jitsi. Bugs can also be reported in the ```issues``` section of the repo.
-
-There's a lot of things that we can enhanced.
-
-* Translating the documentation into English
-* Updating the code to fit latest versions of the technologies used
-* Updating the API to work with the current legislature
-* Adding features to the API
-* Hosting it into the cloud.
-
-#### Technologies used 
-
-* Node.JS, which is a runtime of JavaScript for off-browser, server-side usage
-* Node package manager
-* restify, node-static, mongodb and see-no-evil node libraries
-* MongoDB database language and MongoHQ
-* Nodejitsu
-* JavaScript
-
-Understanding French and the basics of the AssNat is also a plus, although a quick research on the web will give you all the information you need
-
 ## Usability tests in Debian Bullseye
 
 #### The Debian project


### PR DESCRIPTION
I removed the project because my fork of it does not exist anymore.
Node projects can sometimes be a little difficult to maintain.
I might want to recreate a similar project instead sometime in th future.
If I do it would probably be similar to [OpenParliament](https://openparliament.ca) which is a whole full stack web app that helps better understand what is going on in the federal House of Commons parliament.
I think it would be a great idea to do it in Java Spring for the back end and something like Angular/React for the front end
